### PR TITLE
Route whole cluster & service CIDR via ENI/VPC gateway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 jobs:
   include:
     - stage: test
-      script: make build test && sudo $(which go) test -v ./cmd/cni-vpcnet/ -vethtests
+      script: make build test && sudo $(which go) test -v ./cmd/cni-vpcnet/ -vethtests && sudo $(which go) test -v ./pkg/cni/ipmasq -runipmasqtests
       sudo: true
     - stage: deploy
       script: make release

--- a/cmd/cni-vpcnet/main.go
+++ b/cmd/cni-vpcnet/main.go
@@ -105,7 +105,7 @@ func (c *cniRunner) cmdAdd(args *skel.CmdArgs) error {
 			args.ContainerID,
 			alloced.ContainerIP,
 			// Don't masq our traffic, or (service traffic? or does service traffic need to masq from a diff IP?)
-			[]*net.IPNet{alloced.ENISubnet, conf.ServiceCIDR},
+			[]*net.IPNet{conf.ClusterCIDR, conf.ServiceCIDR},
 		)
 		if err != nil {
 			return errors.Wrap(err, "Error inserting IPTables rule")

--- a/manifest-latest.yaml
+++ b/manifest-latest.yaml
@@ -6,6 +6,8 @@ metadata:
 data:
   config.toml: |
     [network]
+    # The range that pods will run in.
+    cluster_cidr = "10.0.0.0/18"
     # The service range for the network. This is needed, because we need to
     # explicitly link route it via the ENI, and there doesn't seem to be a way
     # to easily infer/discover this

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,6 +6,8 @@ metadata:
 data:
   config.toml: |
     [network]
+    # The range that pods will run in.
+    cluster_cidr = "10.0.0.0/18"
     # The service range for the network. This is needed, because we need to
     # explicitly link route it via the ENI, and there doesn't seem to be a way
     # to easily infer/discover this

--- a/pkg/cni/config/config.go
+++ b/pkg/cni/config/config.go
@@ -28,6 +28,9 @@ type CNI struct {
 	// IPMasq will write outbound masquerate iptables rules
 	IPMasq bool `json:"ip_masq"`
 
+	// ClusterCIDR is the CIDR in which pods will run in
+	ClusterCIDR *net.IPNet `json:"cluster_cidr"`
+
 	// ServiceCIDR is the CIDR for the cluster services network. This is needed
 	// to ensure the correct routing for this interface.
 	ServiceCIDR *net.IPNet `json:"service_cidr"`
@@ -52,6 +55,7 @@ func WriteCNIConfig(c *config.Config) error {
 		// Let the paths just use the defaults
 		IPMasq:       c.Network.PodIPMasq,
 		ServiceCIDR:  c.Network.ServiceCIDR.IPNet(),
+		ClusterCIDR:  c.Network.ClusterCIDR.IPNet(),
 		LogVerbosity: c.Logging.CNIVLevel,
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,8 @@ type Config struct {
 
 // Network is the network topology related configuration for this cluster
 type Network struct {
+	// ClusterCIDR is the CIDR in which pods will run in
+	ClusterCIDR *IPNet `toml:"cluster_cidr"`
 	// ServiceCIDR is the CIDR for cluster services
 	ServiceCIDR *IPNet `toml:"service_cidr"`
 	// PodIPMasq indicated if we should masquerade external pod traffic from the


### PR DESCRIPTION
This will take all traffic destined for the cluster ranges and
services, and route them out via the ENI subnets gateway. This
seems to fix up all service to service comms, and comms between
pods in different AZ's.

Fixes #25, #28