### PR TITLE
Clean routes when deleting network

### DIFF
--- a/.gometalinter.cfg.json
+++ b/.gometalinter.cfg.json
@@ -1,0 +1,17 @@
+{
+  "Exclude": [
+    "should have comment.*or be unexported",
+    "\\.gen\\.go",
+    "\\.pb\\.go",
+    "^vendor\/",
+    "error return value not checked.*defer"
+  ],
+  "Enable": [
+    "errcheck",
+    "vet",
+    "golint",
+    "deadcode",
+    "goconst",
+    "staticcheck"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build containers release test cni-bundle
+.PHONY: all build containers release test lint
 
 ifdef TRAVIS_COMMIT
 VERSION := $(shell git rev-parse --short HEAD)
@@ -22,6 +22,9 @@ build:
 
 test:
 	go test -v $$(go list ./... | grep -v /vendor/)
+
+lint:
+	GOOS=linux GOARCH=amd64 gometalinter --config=.gometalinter.cfg.json --deadline=1200s ./...
 
 vethtest:
 	sudo go test -v ./cmd/cni-vpcnet/ -vethtests

--- a/cmd/cni-vpcnet/main_test.go
+++ b/cmd/cni-vpcnet/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path"
 	"testing"
@@ -38,7 +39,7 @@ func (v *testVether) SetupVeth(cfg *config.CNI, contnsPath, ifName string, net *
 	return v.hostIf, v.contIf, v.setupErr
 }
 
-func (v *testVether) TeardownVeth(netns, ifname string) error {
+func (v *testVether) TeardownVeth(cfg *config.CNI, nspath, ifname string, released []net.IP) error {
 	return v.teardownError
 }
 

--- a/cmd/cni-vpcnet/veth.go
+++ b/cmd/cni-vpcnet/veth.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"net"
+
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/lstoll/k8s-vpcnet/pkg/cni/config"
 )
 
 type vether interface {
 	SetupVeth(cfg *config.CNI, netnsPath, ifName string, net *podNet) (*current.Interface, *current.Interface, error)
-	TeardownVeth(netnsPath, ifname string) error
+	TeardownVeth(cfg *config.CNI, nspath, ifname string, released []net.IP) error
 }

--- a/cmd/cni-vpcnet/veth_darwin.go
+++ b/cmd/cni-vpcnet/veth_darwin.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net"
+
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/lstoll/k8s-vpcnet/pkg/cni/config"
 )
@@ -11,6 +13,6 @@ func (v *vetherImpl) SetupVeth(cfg *config.CNI, contnsPath, ifName string, net *
 	return nil, nil, nil
 }
 
-func (v *vetherImpl) TeardownVeth(netns, ifname string) error {
+func (v *vetherImpl) TeardownVeth(cfg *config.CNI, nspath, ifname string, released []net.IP) error {
 	return nil
 }

--- a/cmd/cni-vpcnet/veth_linux_test.go
+++ b/cmd/cni-vpcnet/veth_linux_test.go
@@ -168,7 +168,24 @@ func TestVeth(t *testing.T) {
 			}
 
 			err = hostNS.Do(func(ns.NetNS) error {
-				return v.TeardownVeth(contNS.Path(), "eth0")
+				err := v.TeardownVeth(&config.CNI{IPMasq: tc.Masq}, contNS.Path(), "eth0", []net.IP{pn.ContainerIP})
+				if err != nil {
+					t.Fatalf("Error tearing down veth [%+v]", err)
+				}
+
+				routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+				if err != nil {
+					t.Fatalf("Error fetching host NS routes [%+v]", err)
+				}
+				t.Logf("routes: %+v", routes)
+
+				rules, err := netlink.RuleList(netlink.FAMILY_ALL)
+				if err != nil {
+					t.Fatalf("Error fetching host NS rules [%+v]", err)
+				}
+				t.Logf("rules: %+v", rules)
+
+				return nil
 			})
 			if err != nil {
 				t.Fatalf("Error tearing down veth [%v]")

--- a/pkg/cni/diskstore/backend.go
+++ b/pkg/cni/diskstore/backend.go
@@ -1,0 +1,117 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskstore
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend"
+)
+
+const lastIPFilePrefix = "last_reserved_ip."
+
+var defaultDataDir = "/var/lib/cni/networks"
+
+// Store is a simple disk-backed store that creates one file per IP
+// address in a given directory. The contents of the file are the container ID.
+type Store struct {
+	FileLock
+	dataDir string
+}
+
+// Store implements the Store interface
+var _ backend.Store = &Store{}
+
+func New(network, dataDir string) (*Store, error) {
+	if dataDir == "" {
+		dataDir = defaultDataDir
+	}
+	dir := filepath.Join(dataDir, network)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+
+	lk, err := NewFileLock(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{*lk, dir}, nil
+}
+
+func (s *Store) Reserve(id string, ip net.IP, rangeID string) (bool, error) {
+	fname := filepath.Join(s.dataDir, ip.String())
+	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0644)
+	if os.IsExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if _, err := f.WriteString(strings.TrimSpace(id)); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return false, err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return false, err
+	}
+	// store the reserved ip in lastIPFile
+	ipfile := filepath.Join(s.dataDir, lastIPFilePrefix+rangeID)
+	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0644)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// LastReservedIP returns the last reserved IP if exists
+func (s *Store) LastReservedIP(rangeID string) (net.IP, error) {
+	ipfile := filepath.Join(s.dataDir, lastIPFilePrefix+rangeID)
+	data, err := ioutil.ReadFile(ipfile)
+	if err != nil {
+		return nil, err
+	}
+	return net.ParseIP(string(data)), nil
+}
+
+func (s *Store) Release(ip net.IP) error {
+	return os.Remove(filepath.Join(s.dataDir, ip.String()))
+}
+
+// N.B. This function eats errors to be tolerant and
+// release as much as possible
+func (s *Store) ReleaseByID(id string) error {
+	err := filepath.Walk(s.dataDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		if strings.TrimSpace(string(data)) == strings.TrimSpace(id) {
+			if err := os.Remove(path); err != nil {
+				return nil
+			}
+		}
+		return nil
+	})
+	return err
+}

--- a/pkg/cni/diskstore/lock.go
+++ b/pkg/cni/diskstore/lock.go
@@ -1,0 +1,50 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskstore
+
+import (
+	"os"
+	"syscall"
+)
+
+// FileLock wraps os.File to be used as a lock using flock
+type FileLock struct {
+	f *os.File
+}
+
+// NewFileLock opens file/dir at path and returns unlocked FileLock object
+func NewFileLock(path string) (*FileLock, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileLock{f}, nil
+}
+
+// Close closes underlying file
+func (l *FileLock) Close() error {
+	return l.f.Close()
+}
+
+// Lock acquires an exclusive lock
+func (l *FileLock) Lock() error {
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_EX)
+}
+
+// Unlock releases the lock
+func (l *FileLock) Unlock() error {
+	return syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+}


### PR DESCRIPTION
We were previously leaking routes when freeing networks. This looks for route/rule entries for the freed container IP, and deletes them

Fixes #19 