### PR TITLE
Determine main interface name from metadata

### DIFF
--- a/cmd/vpcnet-configure/main.go
+++ b/cmd/vpcnet-configure/main.go
@@ -407,7 +407,8 @@ func (c *controller) handleErr(err error, key interface{}) {
 	c.queue.Forget(key)
 	// Report to an external entity that, even after several retries, we could not successfully process this key
 	runtimeutil.HandleError(err)
-	glog.Infof("Dropping node %q out of the queue: %v", key, err)
+
+	glog.Fatalf("Repeated errors processing node %q [%+v]", key, err)
 }
 
 func (c *controller) Run(threadiness int, stopCh chan struct{}) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,9 @@ type Network struct {
 	// InstanceMetadataRedirectPort is the port on the machines main IP we
 	// should redirect all instance metadata traffic to. Use with kube2iam
 	InstanceMetadataRedirectPort int `toml:"instance_metadata_redirect_port"`
+	// HostPrimaryInterface is the name of the main interface in the machine,
+	// i.e what masq should egress. If not set, inferred from metadata API.
+	HostPrimaryInterface string `toml:"host_primary_interface"`
 }
 
 // Logging is the master configuration for this app. It is updated from a ConfigMap

--- a/pkg/ifmgr/ifmgr_linux.go
+++ b/pkg/ifmgr/ifmgr_linux.go
@@ -93,9 +93,9 @@ func (i *IFMgr) ConfigureRoutes(ifName string, awsEniAttachIndex int, eniSubnet 
 		// still pushed out the eni
 
 		// TODO - have this configured, or inferred smarter?
-		eth0, err := netlink.LinkByName("eth0")
+		eth0, err := netlink.LinkByName(i.Network.HostPrimaryInterface)
 		if err != nil {
-			return errors.Wrap(err, "failed to lookup eth0")
+			return errors.Wrapf(err, "failed to lookup %q", i.Network.HostPrimaryInterface)
 		}
 
 		routes = append(routes, &netlink.Route{


### PR DESCRIPTION
Previously had hardcoded eth0, which is a terrible assumption. Use
the metadata API to find the MAC, then look up what interface it
corresponds to.

Fixes #41