### PR TITLE
Delay freeing IP's in reconciler

### DIFF
--- a/cmd/vpcnet-configure/main.go
+++ b/cmd/vpcnet-configure/main.go
@@ -314,10 +314,11 @@ func (c *controller) handleNode(key string) error {
 		defer store.Close()
 
 		c.reconciler = &reconciler{
-			store:     store,
-			indexer:   c.indexer,
-			nodeName:  node.Name,
-			clientSet: c.clientSet,
+			store:        store,
+			indexer:      c.indexer,
+			nodeName:     node.Name,
+			clientSet:    c.clientSet,
+			missingSince: map[string]time.Time{},
 		}
 
 		go func() {


### PR DESCRIPTION
We were currently checking faster than we were getting pods back
from kubelet. Wait a reasonable time (5 minutes) for a pod to
consistently not show in kubelet's API before releasing it's
allocation. Also don't error deleting a not found pod, that's
what we wanted anyway.