### PR TITLE
Configurable interfaces to route via VPC

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,6 +16,10 @@ data:
     # main interface. Generally this will be desired, unless you have a NAT
     # Gateway set on the subnet the pods reside in.
     pod_ip_masq = true
+    # If we're masquerading traffic, additional subnets that should be routed
+    # via the VPC subnet's gateway, rather than masqueraded from the host.
+    # Generally this will be things that you peer to etc.
+    vpc_routed = [ "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" ]
     # Where we should redirect traffic destined for the instance metadata
     # endpoint. Calls to it will be rewrote to the machines main IP on the
     # specified port. Intended for use with https://github.com/jtblin/kube2iam .

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,6 +70,9 @@ type Network struct {
 	// PodIPMasq indicated if we should masquerade external pod traffic from the
 	// hosts's main interface
 	PodIPMasq bool `toml:"pod_ip_masq"`
+	// VPCRouted are additional addresses to route via the VPC subnet gateway,
+	// rather than via the host's IP.
+	VPCRouted []*IPNet `toml:"vpc_routed"`
 	// InstanceMetadataRedirectPort is the port on the machines main IP we
 	// should redirect all instance metadata traffic to. Use with kube2iam
 	InstanceMetadataRedirectPort int `toml:"instance_metadata_redirect_port"`


### PR DESCRIPTION
When doing outbound comms with masquerade on, all non-VPC local
traffic is masqueraded out the host. This falls down when using
things like VPC peering, as these really need to be routed via the
VPC too. Introduce a configurable set of networks to route via the
VPC gateway, and skip masquerading. Add the RFC1918 networks as
a default set.