### PR TITLE
Don't configure CNI until interfaces are ready

### DIFF
--- a/cmd/vpcnet-configure/install.go
+++ b/cmd/vpcnet-configure/install.go
@@ -11,6 +11,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+func cniConfigured() (bool, error) {
+	if _, err := os.Stat(cniconfig.CNIConfigPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "Error checking CNI config path")
+	}
+	return true, nil
+}
+
 func installCNI(cfg *config.Config) error {
 	err := os.MkdirAll("/opt/cni/bin", 0755)
 	if err != nil {

--- a/pkg/cni/config/config.go
+++ b/pkg/cni/config/config.go
@@ -15,6 +15,9 @@ const cniConfigPath = "/etc/cni/net.d/10-vpcnet.conf"
 
 const CNIName = "vpcnet"
 
+// CNIConfigPath is where the configuration is written to for CNI
+const CNIConfigPath = "/etc/cni/net.d/10-vpcnet.conf"
+
 // CNI represents the configuration that our CNI plugin receives
 type CNI struct {
 	Name       string `json:"name"`
@@ -66,7 +69,7 @@ func WriteCNIConfig(c *config.Config) error {
 		return errors.Wrap(err, "Error marshaling CNI JSON")
 	}
 
-	err = ioutil.WriteFile("/etc/cni/net.d/10-vpcnet.conf", cniJSON, 0644)
+	err = ioutil.WriteFile(CNIConfigPath, cniJSON, 0644)
 	if err != nil {
 		return errors.Wrap(err, "Error writing CNI configuration JSON")
 	}


### PR DESCRIPTION
With no interfaces, the CNI driver isn't going to do anything anyway. So
don't configure it until it's feasible for it to work. This should keep the
node in a not ready state, which will prevent pods being scheduled to it.