### PR TITLE
Update manifest and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,36 @@
 
 [![Build Status](https://travis-ci.org/lstoll/k8s-vpcnet.svg?branch=master)](https://travis-ci.org/lstoll/k8s-vpcnet)
 
-STATUS: _Prototype_. Still rough with many known and unknown issues
+STATUS: beta. Still needs more testing, and likely to have breaking changes
 
 Kubernetes networking implementation for AWS that assigns Pods direct VPC routable IP addresses without using an overlay or hitting the 50/100 route limit.
 
-This is done by utilizing ENI's with additional IPs bound. This is managed via a controller that creates the ENI's and IP bindings, a DaemonSet that configures interfaces and writes a CNI configuration, and a CNI plugin that configures the pod network and routing appropriately.
+This is done by utilizing ENI's with additional IPs bound. This is managed via a central controller that creates the ENI's and IP bindings, a DaemonSet that configures interfaces and writes a CNI configuration, and a CNI plugin that acts as an IPAM. For the actual container interfaces, the normal [CNI ptp plugin](https://github.com/containernetworking/plugins/blob/master/plugins/main/ptp/README.md) is used.
 
-[Design Doc](https://docs.google.com/document/d/1A5uQ22KlRCy-SR7OtRqTTROPc2BGBYc-nosG2-Pd2fs)
+This is not the only way to to manage this on AWS. Alternatives are:
+* Amazon's [amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s)
+* Lyft's [cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s)
+
+If you're just looking for something general purpose, I'd recommend checking out AWS's. It'll probably be the easiest to get support for, and will plug in with their managed Kubernetes service. If you're looking for the best networking performance, Lyft's is what you want.
+
+Development on this project is ongoing, and will become more opinionated.
+
+### Current design items of note:
+
+#### Centralized network configuration.
+
+Unlike the other projects, ENIs, addresses and their attachment are managed via a central daemon as opposed to running per-node. This makes troubleshooting issues in this area simpler, and removes the need for every node to have IAM permissions. We also configured the maximum number of ENIs and addresses as soon as the node comes online, and before it starts accepting pods. This removes moving parts in normal node operation, simplifying the path of pod creation and minimizing external failures affecting this.
+
+#### Up-front configuration per-pod
+
+The daemon creates the host interfaces and configures all possible iptables rules and routes up front. This again streamlines the process of bringing a pod online. The existence of this daemon and it's informed involvement in the pod address allocation process provides a good place to implement NetworkPolicy and IAM management without suffering from configuration races. We can also put pods in different security groups/VPC subnets based on annotations.
+
+#### Address pool management
+
+A much smaller address pool than Kubernetes normally expects is available to AWS instances. To work around this, the system can manage a taint (`k8s-vpcnet/no-free-ips:NoSchedule`) on nodes to prevent pods being scheduled on nodes with an exhausted pool. Pods that fail to create can also optionally be automatically deleted. This is preferred over `--max-pods`, as it can take host network pods in to account
+
+
+[Early Design Doc](https://docs.google.com/document/d/1A5uQ22KlRCy-SR7OtRqTTROPc2BGBYc-nosG2-Pd2fs)
 
 # Deploying
 
@@ -39,16 +62,12 @@ Only single instance of this should be run in the cluster currently. This will w
 
 ## vpcnet-daemon
 
-This runs as a DaemonSet on all nodes. It installs the CNI plugin on the node. This watches for node changes by the instance ID label. When the node has ENI's and IPs allocated it will create the network interface in the OS, and set up the appropriate routes and iptables entries. It will then write out a config for the CNI plugin
+This runs as a DaemonSet on all nodes. It installs the CNI plugins on the node. This watches for node changes by the instance ID label. When the node has ENI's and IPs allocated it will create the network interface in the OS, and set up the appropriate routes and iptables entries. It will then write out a config for the CNI plugin. It exports a gRPC service over a unix socket that the CNI IPAM plugin uses to request addresses.
 
 ## CNI Plugin
 
-Using the configuration the configure process write out, when called it will allocate an IP for the pod and configure a veth pair and routing for the namespace.
+IPAM-only plugin that communicates with the vpcnet-daemon to assign an IP address
 
-# More
-
-This is still in flux and a work in progress. The core concepts are comfortable, but the implementation needs more testing in large environments and handlers for all the inevetable edge cases.
-
-The licensing of this is TBD right now, still trying to work it out appropriately. If this is an immediately blocker for you please let me know and I'll hurry it up.
+# Contact
 
 I can be contacted at lincoln.stoll@gmail.com or @lstoll in the kubernetes slack.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,6 +5,16 @@ metadata:
   namespace: kube-system
 data:
   config.toml: |
+    # indicates if we should add a k8s-vpcnet/no-free-ips:NoSchedule
+    # taint to the node when the IP address allocation pool is empty
+    taint_when_no_ips = true
+    # will make the allocator delete the pod from the
+    # kubernetes API when a pod IP allocation request fails (running pods
+    # remain untouched. This can help recover from this situation, but assumes
+    # that the user is OK when this happens (and has a mechanism in place for
+    # the pod to be re-created)
+    delete_pod_when_no_ips = true
+
     [network]
     # The range that pods will run in.
     cluster_cidr = "10.0.0.0/18"
@@ -32,7 +42,9 @@ data:
     # The verbosity level for CNI plugin. Higher to begin with, to make sure we
     # have diagnostic info
     cni_v_level = 2
+
 ---
+
 apiVersion: extensions/v1beta1
 # Schedule as a daemonset - this will ignore the race where networking isn't
 # ready which will block this coming up and configuring networking
@@ -85,8 +97,9 @@ spec:
           effect: NoSchedule
         - key: "k8s-vpcnet/no-free-ips"
           effect: NoSchedule
-      hostNetwork: true
+
 ---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -95,7 +108,9 @@ metadata:
     app: eni-controller
   name: eni-controller
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -114,7 +129,9 @@ rules:
   - list
   - get
   - update
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -131,7 +148,9 @@ subjects:
   - kind: ServiceAccount
     name:  eni-controller
     namespace: kube-system
+
 ---
+
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -203,6 +222,7 @@ spec:
           effect: NoSchedule
 
 ---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -211,7 +231,9 @@ metadata:
     app: vpcnet-daemon
   name: vpcnet-daemon
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -221,16 +243,32 @@ metadata:
   #  k8s-addon: cluster-autoscaler.addons.k8s.io
     app: vpcnet-daemon
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - watch
-  - list
-  - get
-  - update
+  # Daemon needs to be able to watch and manipulate nodes to read
+  # interface configuration, and interact with taints
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - watch
+    - list
+    - get
+    - update
+  # Daemon needs to be able to interact with pods to delete oversubscribed
+  # (and enforce policy in the future).
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - watch
+    - list
+    - get
+    - update
+    - delete
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Manifest gets updated for the new eviction config items, defaulting to
enabled. Daemon serviceaccount is granted permissions to manipulate pods,
so it can delete oversubscribed ones.

README updated to reflect current state a bit better.